### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# PRAGMA
+#
+* @pragma-org/Board


### PR DESCRIPTION
This should restrict allowed reviewers for our pull requests so its just Board members who count in the approval process